### PR TITLE
Add a test to the mark sweep collector and some general cleanup

### DIFF
--- a/oscars/Cargo.toml
+++ b/oscars/Cargo.toml
@@ -8,4 +8,6 @@ hashbrown = "0.16.1"
 oscars_derive = { path = "../oscars_derive", version = "0.1.0" }
 
 [features]
+default = ["mark_sweep"]
 std = []
+mark_sweep = []

--- a/oscars/src/collectors/mark_sweep/mod.rs
+++ b/oscars/src/collectors/mark_sweep/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 use rust_alloc::vec::Vec;
 
 mod pointers;
-mod trace;
+pub(crate) mod trace;
 
 pub mod cell;
 
@@ -21,9 +21,7 @@ mod tests;
 
 pub(crate) mod internals;
 
-pub use trace::{Finalize, Trace, TraceColor};
-
-pub use oscars_derive::{Finalize, Trace};
+pub use trace::{Trace, Finalize, TraceColor};
 
 pub use pointers::{Gc, WeakGc};
 

--- a/oscars/src/collectors/mark_sweep/pointers/mod.rs
+++ b/oscars/src/collectors/mark_sweep/pointers/mod.rs
@@ -2,6 +2,7 @@
 
 mod gc;
 mod weak;
+mod weak_map;
 
 pub use gc::Gc;
 pub use weak::WeakGc;

--- a/oscars/src/lib.rs
+++ b/oscars/src/lib.rs
@@ -5,10 +5,18 @@
 
 #![no_std]
 
+extern crate self as oscars;
+
 extern crate alloc as rust_alloc;
 
-//#[cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
+
+#[cfg(feature = "mark_sweep")]
+pub use crate::collectors::mark_sweep::*;
+#[cfg(feature = "mark_sweep")]
+pub use oscars_derive::{Trace, Finalize};
+
 
 pub mod alloc;
 pub mod collectors;


### PR DESCRIPTION
This PR adds some general fixes from the previous updates and adds some more tests from `boa_gc`. The new test does pass while running MIRI :partying_face: 

So that's pretty exciting news on that front. So far we are not running into any memory unsoundness or UB with the current version of the arena allocator.