### PR TITLE
test: improve test coverage for mark_sweep

### DIFF
--- a/oscars/src/collectors/mark_sweep/tests.rs
+++ b/oscars/src/collectors/mark_sweep/tests.rs
@@ -71,8 +71,8 @@ fn gc_recursion() {
     let mut root = Gc::new_in(S { i: 0, next: None }, collector);
     for i in 1..COUNT {
         root = Gc::new_in(S {
-            i,
-            next: Some(root),
+                i,
+                next: Some(root),
         }, collector);
     }
 
@@ -80,3 +80,107 @@ fn gc_recursion() {
     collector.collect();
 }
 
+#[test]
+fn drop_gc() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let gc = Gc::new_in(GcRefCell::new(7u64), collector);
+    assert_eq!(collector.allocator.arenas_len(), 1);
+
+    collector.collect();
+    assert_eq!(collector.allocator.arenas_len(), 1);
+
+    drop(gc);
+    collector.collect();
+
+	// TODO: don't drop an active arena
+    assert_eq!(collector.allocator.arenas_len(), 0, "arena not freed");
+}
+
+#[test]
+fn clone_gc() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let gc = Gc::new_in(GcRefCell::new(42u32), collector);
+    let gc_clone = gc.clone();
+
+    drop(gc);
+    collector.collect();
+
+    assert_eq!(*gc_clone.borrow(), 42u32, "collected despite live clone");
+}
+
+#[test]
+fn multi_gc() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(128)
+        .with_heap_threshold(512);
+
+    for _ in 0..3 {
+        let objects: rust_alloc::vec::Vec<_> = (0..4)
+            .map(|i| Gc::new_in(GcRefCell::new(i as u64), collector))
+            .collect();
+
+        assert!(collector.allocator.arenas_len() >= 1);
+
+        drop(objects);
+        collector.collect();
+
+        assert_eq!(collector.allocator.arenas_len(), 0, "arenas not reclaimed");
+    }
+}
+
+#[test]
+fn pressure_gc() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(128)
+        .with_heap_threshold(256);
+
+    let root = Gc::new_in(GcRefCell::new(99u64), collector);
+
+    // Keeping all temporaries alive at once so the allocator hits the threshold
+    // and fires a collection while root is still live
+    let _temporaries: rust_alloc::vec::Vec<_> = (0..20u64)
+        .map(|i| Gc::new_in(GcRefCell::new(i), collector))
+        .collect();
+
+    assert_eq!(*root.borrow(), 99u64, "root collected under pressure");
+}
+
+#[test]
+fn borrow_mut_gc() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let gc = Gc::new_in(GcRefCell::new(0u64), collector);
+    *gc.borrow_mut() = 42;
+
+    collector.collect();
+
+    assert_eq!(*gc.borrow(), 42u64, "mutation lost after collect");
+}
+
+#[test]
+fn long_lived_gc() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let gc = Gc::new_in(GcRefCell::new(77u64), collector);
+
+    for _ in 0..10 {
+        collector.collect();
+    }
+
+    assert_eq!(*gc.borrow(), 77u64, "swept during color-flip");
+    assert_eq!(
+        collector.allocator.arenas_len(),
+        1,
+        "arena freed while live"
+    );
+}


### PR DESCRIPTION
Improved test coverage for mark_sweep
added `drop_gc()`, `clone_gc()`,` multi_gc()`, `pressure_gc()`, `borrow_mut_gc()`, `long_lived_gc()` tests

All tests pass 


<img width="800" height="500" alt="Screenshot 2026-02-20 163126" src="https://github.com/user-attachments/assets/b9d90de7-74e4-4fcc-8839-99463293c14e" />

