### PR TITLE
docs(gc): document boa_gc API surface used by the engine

### DIFF
--- a/docs/boa_gc_api_surface.md
+++ b/docs/boa_gc_api_surface.md
@@ -10,6 +10,24 @@ Any alternative garbage collector aiming to replace `boa_gc` (for example, Oscar
 **must implement this interface** to serve as a drop-in replacement. APIs not listed here
 are internal to the collector and are not part of the engine-facing contract.
 
+## Methodology
+
+The API surface documented here was derived by inspecting the current
+`boa_gc` usage inside the Boa repository.
+
+The process included:
+
+- Searching for `use boa_gc::` imports across the engine
+- Inspecting how core types (`Gc`, `WeakGc`, `GcCell`, `Trace`, `Finalize`)
+  are used throughout the codebase
+- Reviewing `Trace` and `Finalize` implementations to understand the
+  traversal contract
+- Inspecting weak structures (`WeakMap`, `WeakRef`) to identify required
+  weak reference semantics
+
+This was done through manual inspection of the Boa engine source to
+extract the GC interface boundary relied upon by the runtime.
+
 ---
 
 ## 2. Core Pointer Types
@@ -24,6 +42,11 @@ are internal to the collector and are not part of the engine-facing contract.
 
 These five types appear in virtually every subsystem of the engine: the object model,
 environments, bytecode compiler, module system, and builtins.
+
+Example usage in Boa:
+
+- https://github.com/boa-dev/boa/blob/main/core/engine/src/object/jsobject.rs
+- https://github.com/boa-dev/boa/blob/main/core/engine/src/value/mod.rs
 
 ---
 
@@ -166,6 +189,11 @@ pub unsafe trait Trace {
 
 Every type stored inside a `Gc<T>` must implement `Trace`. The collector calls `trace`
 during the mark phase to discover reachable objects.
+
+Example implementations:
+
+- https://github.com/boa-dev/boa/blob/main/core/engine/src/object/jsobject.rs
+- https://github.com/boa-dev/boa/blob/main/core/engine/src/context/mod.rs
 
 ### Finalize
 


### PR DESCRIPTION
This PR documents the subset of the `boa_gc` API that the Boa engine
currently depends on.

ref - #27 

Understanding the exact API surface used by the engine is important for:

- future GC improvements
- experimentation with alternative collectors
- maintaining compatibility between the engine and the collector

The document describes pointer types, tracing traits, weak references,
interior mutability primitives, and runtime utilities relied upon by
the engine.

The goal is to provide a clear compatibility contract for any garbage
collector implementation that aims to replace `boa_gc`.

_**The document deliberately avoids internal implementation details (heap vectors, Box allocation, mark-stack internals) and focuses exclusively on the engine → GC interface boundary, making it suitable for inclusion in repository documentation.**_