### PR TITLE
fix: cleanup Path and PathBuf

### DIFF
--- a/oscars/src/collectors/mark_sweep/trace.rs
+++ b/oscars/src/collectors/mark_sweep/trace.rs
@@ -17,8 +17,6 @@ use rust_alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
-#[cfg(feature = "std")]
-use std::path::{Path, PathBuf};
 
 /// Substitute for the [`Drop`] trait for garbage collected types.
 pub trait Finalize {


### PR DESCRIPTION
added `Finalize` and `Trace` impls for `Path` and `PathBuf`. Without this using either inside a GC managed type would fail to compile when `std` is enabled. 
