### PR TITLE
fix: correct TaggedPtr::as_ptr

### DIFF
--- a/oscars/src/alloc/arena2/alloc.rs
+++ b/oscars/src/alloc/arena2/alloc.rs
@@ -115,7 +115,7 @@ impl<T> TaggedPtr<T> {
     }
 
     fn as_ptr(&self) -> *mut T {
-        self.0.map_addr(|addr| addr ^ MASK)
+        self.0.map_addr(|addr| addr & !MASK)
     }
 }
 

--- a/oscars/src/alloc/arena2/tests.rs
+++ b/oscars/src/alloc/arena2/tests.rs
@@ -88,3 +88,34 @@ fn arc_drop() {
 
     assert_eq!(allocator.arenas_len(), 0);
 }
+
+// === test for TaggedPtr::as_ptr === //
+
+// `TaggedPtr::as_ptr` must use `addr & !MASK` to unconditionally clear the high
+// bit rather than XORing it out. The XOR approach worked for tagged items
+// but incorrectly flipped the bit on untagged items, corrupting the pointer.
+#[test]
+fn as_ptr_clears_not_flips_tag_bit() {
+    let mut allocator = ArenaAllocator::default();
+
+    let mut ptr_a = allocator.try_alloc(1u64).unwrap().as_ptr();
+    let mut ptr_b = allocator.try_alloc(2u64).unwrap().as_ptr();
+    let _ptr_c = allocator.try_alloc(3u64).unwrap().as_ptr();
+    assert_eq!(allocator.arenas_len(), 1);
+
+    // Mark B and C as dropped, leave A live.
+    unsafe {
+        ptr_b.as_mut().mark_dropped();
+    }
+
+    let states = allocator.arena_drop_states();
+    assert_eq!(
+        states[0].as_slice(),
+        &[false, true, false],
+        "item_drop_states must correctly report live/dropped status for all nodes"
+    );
+
+    unsafe {
+        ptr_a.as_mut().mark_dropped();
+    }
+}


### PR DESCRIPTION
the `TaggedPtr::as_ptr` method was previously using XOR to remove the tag bit , this incorrectly corrupted untagged pointers by tagging them. Fixed it to use `addr & !MASK` to safely clear the tag bit without modifying untagged addresses.

`run_drop_check` never caught this bug because the function iterates backwards and early returns false immediately on encountering an untagged pointer. 

I guess this should be fixed to ensure the correctness of `as_ptr()` function 

Added test `as_ptr_clears_not_flips_tag_bit()` to verify the failure, the test failed without the fix

before the fix:
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/72296275-f05f-41b0-afed-1c4d605a8726" />


