### PR TITLE
Use cfg_attr instead for no_std

### DIFF
--- a/oscars/src/lib.rs
+++ b/oscars/src/lib.rs
@@ -3,14 +3,11 @@
 //! Things that may be contained here in: allocators, garbage collectors, memory
 //! management primitives.
 
-#![no_std]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 extern crate self as oscars;
 
 extern crate alloc as rust_alloc;
-
-#[cfg(feature = "std")]
-extern crate std;
 
 #[cfg(feature = "mark_sweep")]
 pub use crate::collectors::mark_sweep::*;


### PR DESCRIPTION
This is probably cleaner