### PR TITLE
mark_sweep: trigger deferred collection for external allocations

### DIFF
--- a/oscars/src/collectors/mark_sweep/mod.rs
+++ b/oscars/src/collectors/mark_sweep/mod.rs
@@ -471,11 +471,19 @@ unsafe impl allocator_api2::alloc::Allocator for MarkSweepGarbageCollector {
 
         // raw byte allocations skip ensure_capacity
         // and go straight to try_alloc_bytes
-        let result = self
-            .allocator
-            .borrow_mut()
-            .try_alloc_bytes(layout)
-            .map_err(|_| allocator_api2::alloc::AllocError)?;
+        let (result, needs_collect) = {
+            let mut alloc = self.allocator.borrow_mut();
+            let result = alloc
+                .try_alloc_bytes(layout)
+                .map_err(|_| allocator_api2::alloc::AllocError)?;
+            let needs_collect = !alloc.is_below_threshold();
+            (result, needs_collect)
+        };
+
+        // Keep deferred-collection behavior consistent with GC-node allocations.
+        if needs_collect {
+            self.collect_needed.set(true);
+        }
 
         // debug only: track raw allocations for leak detection
         #[cfg(all(debug_assertions, feature = "gc_allocator"))]

--- a/oscars/src/collectors/mark_sweep/tests.rs
+++ b/oscars/src/collectors/mark_sweep/tests.rs
@@ -86,6 +86,31 @@ fn gc_recursion() {
     collector.collect();
 }
 
+#[cfg(feature = "gc_allocator")]
+#[test]
+fn external_allocations_set_deferred_collection_flag_when_threshold_exceeded() {
+    let collector = MarkSweepGarbageCollector::default()
+        .with_page_size(128)
+        .with_heap_threshold(1_024);
+
+    assert!(
+        !collector.collect_needed.get(),
+        "collect_needed should start false"
+    );
+
+    let mut external = allocator_api2::vec::Vec::<u8, &MarkSweepGarbageCollector>::with_capacity_in(
+        2_048, &collector,
+    );
+    external.push(1);
+
+    assert!(
+        collector.collect_needed.get(),
+        "raw allocator pressure should set deferred collection"
+    );
+
+    drop(external);
+}
+
 #[test]
 fn drop_gc() {
     let collector = &mut MarkSweepGarbageCollector::default()


### PR DESCRIPTION
﻿Closes #19

This keeps the fix narrowly scoped to mark-sweep allocation accounting.

## What changed
- In `GcAllocator::allocate`, after external/raw allocation via `try_alloc_bytes(layout)`, we now check threshold state and set `collect_needed` when the heap is no longer below threshold.
- Added regression test `external_allocations_set_deferred_collection_flag_when_threshold_exceeded` to verify large external allocations trigger deferred collection.

## Why
External allocations were bypassing deferred-collection signaling, so threshold overflow from raw allocations could go unnoticed until later operations.

## Scope
- mark-sweep internals + tests only
- no public API changes
- no policy/threshold tuning changes

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-features --all-targets`
- `cargo clippy --workspace --no-default-features --all-targets`
- `cargo doc -v --document-private-items --all-features`
- `cargo +nightly miri test -p oscars --all-features`
