### PR TITLE
docs(gc): add precise-tracing API redesign plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ management and garbage collection experiments for Boa.
 The current API model investigation for Boa issue #2631 is documented in
 [`notes/gc_api_models.md`](./notes/gc_api_models.md).
 
+The current implementation-focused follow-up for a precise-tracing API (post
+`gc_allocator`) is documented in
+[`notes/precise_tracing_api_plan.md`](./notes/precise_tracing_api_plan.md).
+
 ## Project structure
 
 The current project structure is as follows.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ management and garbage collection experiments for Boa.
 The current API model investigation for Boa issue #2631 is documented in
 [`notes/gc_api_models.md`](./notes/gc_api_models.md).
 
-The current implementation-focused follow-up for a precise-tracing API (post
-`gc_allocator`) is documented in
+The current precise-tracing API redesign proposal (post `gc_allocator`) is
+documented in
 [`notes/precise_tracing_api_plan.md`](./notes/precise_tracing_api_plan.md).
 
 ## Project structure

--- a/notes/precise_tracing_api_plan.md
+++ b/notes/precise_tracing_api_plan.md
@@ -1,0 +1,158 @@
+# Precise-Tracing API Plan (Post `gc_allocator`)
+
+Date: 2026-03-19
+
+## Context
+
+This note proposes a concrete API-design and implementation plan for the
+GC redesign track after removing the `Collector: Allocator` experiment
+(`#54`).
+
+It builds on:
+
+- `notes/gc_api_models.md` (model-family investigation for boa#2631)
+- `docs/boa_gc_api_surface.md` (current Boa-facing GC contract)
+- Oscars integration tracker issues (`#26`, `#27`, `#28`, `#30`)
+
+The objective is to design a GC API that does **not** rely on root/reference
+counting for liveness, while preserving precise tracing semantics and providing
+an incremental integration path into Boa.
+
+## Problem statement
+
+Today, root/reference counts are coupled with public pointer ergonomics and
+collector internals. This coupling increases implementation complexity and
+makes it harder to evolve collector strategy.
+
+For a redesign to be integration-ready, we need:
+
+1. A pointer/rooting API where liveness is derived from precise tracing.
+2. Explicit invariants for weak/ephemeron/finalizer behavior.
+3. A staged migration path that can run behind feature gates in Boa.
+
+## Design goals
+
+1. Precise tracing as the source of truth for liveness.
+2. Context-safe pointer model (no accidental cross-context sharing).
+3. Weak and ephemeron behavior parity with current Boa semantics.
+4. Finalization semantics that are explicit and testable.
+5. Incremental adoption (no big-bang replacement).
+
+## Non-goals (for this phase)
+
+1. Generational or incremental collector algorithm rollout.
+2. Concurrent collector implementation.
+3. Full allocator-framework redesign in the same milestone.
+4. Public engine-wide API churn in one PR.
+
+## Core invariants
+
+### I1. Tracing invariant
+
+Any object reachable from roots through strong edges must be marked alive in the
+same collection cycle.
+
+### I2. Rooting invariant
+
+Rooting API must make temporary and long-lived roots explicit, and prevent
+silent loss of roots due to API misuse.
+
+### I3. Weak invariant
+
+Weak handles do not keep referents alive. Upgrades succeed only if referent is
+alive at upgrade time.
+
+### I4. Ephemeron invariant
+
+Ephemeron value is considered reachable only when key is independently
+reachable by strong tracing rules.
+
+### I5. Finalizer invariant
+
+Finalization happens before drop/reclaim. If finalization can make objects
+reachable again, collection ordering must prevent use-after-free.
+
+### I6. Teardown invariant
+
+Collector-drop paths must preserve safety ordering and avoid freeing objects
+that may still be referenced by finalizer-triggered graph activity.
+
+## Proposed API direction (high-level)
+
+1. Keep user-facing `Gc<T>` ergonomics close to current behavior where possible.
+2. Shift internal liveness authority to tracing rather than root/refcount
+   arithmetic.
+3. Make rooting scopes/handles explicit in API boundaries where ambiguity
+   exists.
+4. Keep weak and ephemeron APIs stable at surface level while tightening
+   internal reachability contracts.
+
+This allows incremental migration while reducing dependence on reference-count
+based root detection.
+
+## Implementation phases
+
+### Phase 1: API contract and invariant harness
+
+1. Add a dedicated invariant checklist and edge-case test matrix.
+2. Expand coverage for rooting misuse, weak upgrades, ephemeron pruning, and
+   finalizer/resurrection-sensitive flows.
+3. Define acceptance criteria for parity against `docs/boa_gc_api_surface.md`.
+
+Deliverable:
+
+- Invariant-driven test suite and API-diff checklist.
+
+### Phase 2: Oscars prototype changes
+
+1. Prototype precise-tracing-first liveness flow in Oscars internals.
+2. Keep changes in reviewable slices (pointer semantics, tracing hooks, weak/
+   ephemeron behavior).
+3. Ensure Miri-clean behavior throughout.
+
+Deliverable:
+
+- Prototype branch with passing invariants and stress tests.
+
+### Phase 3: Boa integration path (feature-gated)
+
+1. Map prototype API to Boa `core/gc` surface.
+2. Integrate behind unstable gate with fallback to existing path.
+3. Validate on Boa-relevant workloads, not only microbenchmarks.
+
+Deliverable:
+
+- Gated integration slices plus benchmark and migration notes.
+
+## Validation strategy
+
+1. Correctness
+   - Targeted unit/regression tests for each invariant.
+   - Workspace test suites pass.
+2. Safety
+   - Miri coverage for critical paths.
+3. Performance
+   - Boa workload benchmarks plus focused GC stress tests.
+4. Integration confidence
+   - API parity matrix against `docs/boa_gc_api_surface.md`.
+
+## Risk management
+
+1. Scope creep
+   - Keep non-goals explicit and enforce slice-based PRs.
+2. Unsoundness regressions
+   - Require invariant tests before merging behavioral changes.
+3. Integration disruption
+   - Use feature-gated rollout and preserve fallback path.
+
+## Relationship to active tracker work
+
+This plan is intended to feed directly into:
+
+- `#26` Tracking issue for Boa integration
+- `#27` Coverage of `boa_gc` API surface area
+- `#28` Integration into Boa
+- `#30` Benchmark MarkSweepGarbageCollector in Boa with `arena3` allocator
+
+And it is explicitly aligned with the `#54` direction to remove the
+`gc_allocator` supertrait experiment.

--- a/notes/precise_tracing_api_plan.md
+++ b/notes/precise_tracing_api_plan.md
@@ -1,158 +1,206 @@
-# Precise-Tracing API Plan (Post `gc_allocator`)
+# Precise-Tracing API Redesign Proposal (Post `gc_allocator`)
 
 Date: 2026-03-19
 
 ## Context
 
-This note proposes a concrete API-design and implementation plan for the
-GC redesign track after removing the `Collector: Allocator` experiment
-(`#54`).
+After removing the `Collector: Allocator` experiment (`#54`), the next step is
+to propose a concrete API redesign shape that can be discussed and tested.
 
-It builds on:
+This note builds on:
 
 - `notes/gc_api_models.md` (model-family investigation for boa#2631)
 - `docs/boa_gc_api_surface.md` (current Boa-facing GC contract)
-- Oscars integration tracker issues (`#26`, `#27`, `#28`, `#30`)
+- Tracker issues `#26`, `#27`, `#28`, `#30`
 
-The objective is to design a GC API that does **not** rely on root/reference
-counting for liveness, while preserving precise tracing semantics and providing
-an incremental integration path into Boa.
+The core target is a precise-tracing API that does not use root/reference
+count arithmetic as the liveness authority.
 
 ## Problem statement
 
-Today, root/reference counts are coupled with public pointer ergonomics and
-collector internals. This coupling increases implementation complexity and
-makes it harder to evolve collector strategy.
+Today, `Gc<T>` ergonomics and liveness accounting are tightly coupled to root
+counting. That gives simple usage but makes collector internals harder to
+evolve and reason about.
 
-For a redesign to be integration-ready, we need:
+For redesign work to be useful to Boa, we need an API that:
 
-1. A pointer/rooting API where liveness is derived from precise tracing.
-2. Explicit invariants for weak/ephemeron/finalizer behavior.
-3. A staged migration path that can run behind feature gates in Boa.
+1. uses tracing as the single source of liveness truth,
+2. keeps weak/ephemeron/finalizer semantics explicit,
+3. remains adoptable against the current Boa-facing API surface.
 
-## Design goals
+## Proposed API (draft v0)
 
-1. Precise tracing as the source of truth for liveness.
-2. Context-safe pointer model (no accidental cross-context sharing).
-3. Weak and ephemeron behavior parity with current Boa semantics.
-4. Finalization semantics that are explicit and testable.
-5. Incremental adoption (no big-bang replacement).
+This proposal uses an explicit root-table model with scope handles.
 
-## Non-goals (for this phase)
+### Core types
 
-1. Generational or incremental collector algorithm rollout.
-2. Concurrent collector implementation.
-3. Full allocator-framework redesign in the same milestone.
-4. Public engine-wide API churn in one PR.
+```rust
+pub struct Gc<T: Trace + ?Sized> {
+    ptr: GcErasedPointer,
+    _marker: core::marker::PhantomData<T>,
+}
 
-## Core invariants
+pub struct Root<T: Trace + ?Sized> {
+    ptr: Gc<T>,
+    slot: RootSlotId,
+}
 
-### I1. Tracing invariant
+pub struct WeakGc<T: Trace + ?Sized> {
+    ptr: GcErasedPointer,
+    _marker: core::marker::PhantomData<T>,
+}
 
-Any object reachable from roots through strong edges must be marked alive in the
-same collection cycle.
+pub struct GcContext {
+    /* collector state + root table + weak queues */
+}
 
-### I2. Rooting invariant
+pub struct Scope<'gc> {
+    cx: &'gc mut GcContext,
+}
+```
 
-Rooting API must make temporary and long-lived roots explicit, and prevent
-silent loss of roots due to API misuse.
+### Allocation and rooting
 
-### I3. Weak invariant
+```rust
+impl GcContext {
+    pub fn scope<R>(&mut self, f: impl for<'gc> FnOnce(Scope<'gc>) -> R) -> R;
+    pub fn collect(&mut self);
+}
 
-Weak handles do not keep referents alive. Upgrades succeed only if referent is
-alive at upgrade time.
+impl<'gc> Scope<'gc> {
+    pub fn alloc<T: Trace + 'static>(&mut self, value: T) -> Gc<T>;
+    pub fn root<T: Trace + 'static>(&mut self, value: &Gc<T>) -> Root<T>;
+    pub fn downgrade<T: Trace + 'static>(&self, value: &Gc<T>) -> WeakGc<T>;
+}
 
-### I4. Ephemeron invariant
+impl<T: Trace + ?Sized> Root<T> {
+    pub fn gc(&self) -> &Gc<T>;
+}
+```
 
-Ephemeron value is considered reachable only when key is independently
-reachable by strong tracing rules.
+### Pointer identity and casts (parity-preserving)
 
-### I5. Finalizer invariant
+```rust
+impl<T: Trace + ?Sized> Gc<T> {
+    pub fn ptr_eq<U: Trace + ?Sized>(a: &Gc<T>, b: &Gc<U>) -> bool;
+    pub fn into_raw(this: Gc<T>) -> GcRaw;
+    pub unsafe fn from_raw(raw: GcRaw) -> Gc<T>;
 
-Finalization happens before drop/reclaim. If finalization can make objects
-reachable again, collection ordering must prevent use-after-free.
+    pub fn downcast<U: Trace + 'static>(this: Gc<T>) -> Option<Gc<U>>;
+    pub unsafe fn cast_unchecked<U: Trace + 'static>(this: Gc<T>) -> Gc<U>;
+    pub unsafe fn cast_ref_unchecked<U: Trace + 'static>(this: &Gc<T>) -> &Gc<U>;
+}
+```
 
-### I6. Teardown invariant
+### Weak behavior
 
-Collector-drop paths must preserve safety ordering and avoid freeing objects
-that may still be referenced by finalizer-triggered graph activity.
+```rust
+impl<T: Trace + ?Sized> WeakGc<T> {
+    pub fn new(value: &Gc<T>) -> WeakGc<T>;
+    pub fn upgrade(&self) -> Option<Gc<T>>;
+}
+```
 
-## Proposed API direction (high-level)
+### Runtime helpers
 
-1. Keep user-facing `Gc<T>` ergonomics close to current behavior where possible.
-2. Shift internal liveness authority to tracing rather than root/refcount
-   arithmetic.
-3. Make rooting scopes/handles explicit in API boundaries where ambiguity
-   exists.
-4. Keep weak and ephemeron APIs stable at surface level while tightening
-   internal reachability contracts.
+```rust
+impl GcContext {
+    pub fn finalizer_safe(&self) -> bool;
+}
+```
 
-This allows incremental migration while reducing dependence on reference-count
-based root detection.
+`force_collect()` compatibility can be provided by wiring to
+`MarkSweepGarbageCollector::collect` in integration mode.
 
-## Implementation phases
+## Semantics and invariants
 
-### Phase 1: API contract and invariant harness
+### I1. Tracing is authoritative
 
-1. Add a dedicated invariant checklist and edge-case test matrix.
-2. Expand coverage for rooting misuse, weak upgrades, ephemeron pruning, and
-   finalizer/resurrection-sensitive flows.
-3. Define acceptance criteria for parity against `docs/boa_gc_api_surface.md`.
+Reachability is determined only by tracing from root slots and strong graph
+edges in the same cycle.
 
-Deliverable:
+### I2. Root slots replace root counts
 
-- Invariant-driven test suite and API-diff checklist.
+A value is rooted when at least one root slot references it. Slot lifetime is
+explicit (`Root<T>` drop unregisters slot). No per-object root/refcount math is
+used for liveness.
 
-### Phase 2: Oscars prototype changes
+### I3. Weak upgrade semantics
 
-1. Prototype precise-tracing-first liveness flow in Oscars internals.
-2. Keep changes in reviewable slices (pointer semantics, tracing hooks, weak/
-   ephemeron behavior).
-3. Ensure Miri-clean behavior throughout.
+`WeakGc::upgrade` succeeds only if the referent is marked live in the current
+collector state.
 
-Deliverable:
+### I4. Ephemeron semantics
 
-- Prototype branch with passing invariants and stress tests.
+Ephemeron values are traced only when keys are independently reachable via
+strong edges.
 
-### Phase 3: Boa integration path (feature-gated)
+### I5. Finalizer ordering
 
-1. Map prototype API to Boa `core/gc` surface.
-2. Integrate behind unstable gate with fallback to existing path.
-3. Validate on Boa-relevant workloads, not only microbenchmarks.
+Finalize-before-drop ordering is preserved, and collector teardown runs
+finalizers before destructors for tracked live values.
 
-Deliverable:
+### I6. Teardown safety
 
-- Gated integration slices plus benchmark and migration notes.
+Collector drop does not free values in an order that can cause UAF via
+finalizer-triggered graph activity.
 
-## Validation strategy
+## Feasibility and adoption path
 
-1. Correctness
-   - Targeted unit/regression tests for each invariant.
-   - Workspace test suites pass.
-2. Safety
-   - Miri coverage for critical paths.
-3. Performance
-   - Boa workload benchmarks plus focused GC stress tests.
-4. Integration confidence
-   - API parity matrix against `docs/boa_gc_api_surface.md`.
+This proposal is intentionally structured in two layers:
 
-## Risk management
+1. Collector-native API in Oscars (`GcContext`, `Scope`, `Root<T>`).
+2. Boa-compat layer that preserves current surface where required.
 
-1. Scope creep
-   - Keep non-goals explicit and enforce slice-based PRs.
-2. Unsoundness regressions
-   - Require invariant tests before merging behavioral changes.
-3. Integration disruption
-   - Use feature-gated rollout and preserve fallback path.
+### Boa compatibility mapping
 
-## Relationship to active tracker work
+1. `Gc::new(value)`:
+   - compatibility shim calls `with_gc_context(|cx| cx.scope(|s| s.alloc(value)))`.
+2. `WeakGc::new/upgrade`, raw-pointer helpers, and cast helpers:
+   - keep the same signatures.
+3. `force_collect()`:
+   - routed to collector `collect()`.
+4. `finalizer_safe()`:
+   - routed to collector phase state.
 
-This plan is intended to feed directly into:
+This keeps migration incremental and avoids an all-at-once engine rewrite.
+
+## What this proposal deliberately does not include
+
+1. A new incremental/generational/concurrent algorithm.
+2. Full Boa integration in one milestone.
+3. Allocator-framework redesign in the same proposal.
+
+## Validation plan for this API proposal
+
+1. Contract tests:
+   - rooting slot lifetime and misuse resistance,
+   - weak upgrade behavior across collections,
+   - ephemeron key/value reachability behavior.
+2. Safety checks:
+   - Miri on root registration/unregistration paths and raw round-trips.
+3. Compatibility checks:
+   - parity checklist against `docs/boa_gc_api_surface.md`.
+4. Benchmarks:
+   - Boa workloads plus targeted GC stress cases.
+
+## Open review questions
+
+1. Should `Scope<'gc>` be mandatory for all allocations, or should we keep a
+   global-context fallback for Boa compatibility?
+2. Should `Root<T>` be cloneable (multiple slots) or explicitly unique?
+3. Is `cast_ref_unchecked` still desirable, or should compatibility rely on
+   value-consuming casts only?
+4. Which minimal Boa integration slice gives the best signal first:
+   pointer API parity, weak semantics parity, or runtime helpers?
+
+## Relationship to tracker work
+
+This proposal is intended to feed directly into:
 
 - `#26` Tracking issue for Boa integration
 - `#27` Coverage of `boa_gc` API surface area
 - `#28` Integration into Boa
 - `#30` Benchmark MarkSweepGarbageCollector in Boa with `arena3` allocator
 
-And it is explicitly aligned with the `#54` direction to remove the
-`gc_allocator` supertrait experiment.
+And it is aligned with `#54` (remove `gc_allocator` supertrait direction).

--- a/notes/precise_tracing_api_plan.md
+++ b/notes/precise_tracing_api_plan.md
@@ -52,11 +52,11 @@ pub struct WeakGc<T: Trace + ?Sized> {
 }
 
 pub struct GcContext {
-    /* collector state + root table + weak queues */
+    /* collector state + root table + weak queues (interior mutability) */
 }
 
 pub struct Scope<'gc> {
-    cx: &'gc mut GcContext,
+    cx: &'gc GcContext,
 }
 ```
 
@@ -64,12 +64,12 @@ pub struct Scope<'gc> {
 
 ```rust
 impl GcContext {
-    pub fn scope<R>(&mut self, f: impl for<'gc> FnOnce(Scope<'gc>) -> R) -> R;
-    pub fn collect(&mut self);
+    pub fn scope<R>(&self, f: impl for<'gc> FnOnce(Scope<'gc>) -> R) -> R;
+    pub fn collect(&self);
 }
 
 impl<'gc> Scope<'gc> {
-    pub fn alloc<T: Trace + 'static>(&mut self, value: T) -> Gc<T>;
+    pub fn alloc<T: Trace + 'static>(&self, value: T) -> Gc<T>;
     pub fn root<'scope, T: Trace + 'static>(
         &'scope self,
         value: &Gc<T>,
@@ -89,6 +89,10 @@ dropped.
 Implementation note: `Scope::root(&self, ...)` assumes root-slot registration is
 handled via internal mutability in collector internals, so multiple roots can
 coexist without requiring an exclusive borrow of `Scope`.
+
+Collection note: `collect(&self)` here represents a high-level API shape for a
+single-threaded runtime. Implementations should guard collection phase entry so
+collection cannot race with active mutable interior borrows.
 
 ### Pointer identity and casts (parity-preserving)
 
@@ -169,7 +173,7 @@ This proposal is intentionally structured in two layers:
 
 1. `Gc::new(value)`:
    - compatibility shim calls
-     `with_gc_context(|cx| cx.scope(|mut s| s.alloc(value)))`.
+     `with_gc_context(|cx| cx.scope(|s| s.alloc(value)))`.
 2. `WeakGc::new/upgrade`, raw-pointer helpers, and cast helpers:
    - keep the same signatures.
 3. `force_collect()`:
@@ -204,11 +208,13 @@ This keeps migration incremental and avoids an all-at-once engine rewrite.
    global-context fallback for Boa compatibility?
 2. Should `Root<'scope, 'gc, T>` be cloneable (multiple slots) or explicitly
    unique?
-3. Is `cast_ref_unchecked` still desirable, or should compatibility rely on
+3. Should scope entry be closure-only (`GcContext::scope`) or should we also
+   support an explicit long-lived scope handle for ergonomics/integration?
+4. Is `cast_ref_unchecked` still desirable, or should compatibility rely on
    value-consuming casts only?
-4. Which minimal Boa integration slice gives the best signal first:
+5. Which minimal Boa integration slice gives the best signal first:
    pointer API parity, weak semantics parity, or runtime helpers?
-5. Should reading `T` from `Gc<T>` require an explicit scope/root token, so
+6. Should reading `T` from `Gc<T>` require an explicit scope/root token, so
    stale handles cannot be dereferenced after collection in safe code?
 
 ## Relationship to tracker work

--- a/notes/precise_tracing_api_plan.md
+++ b/notes/precise_tracing_api_plan.md
@@ -40,10 +40,10 @@ pub struct Gc<T: Trace + ?Sized> {
     _marker: core::marker::PhantomData<T>,
 }
 
-pub struct Root<'gc, T: Trace + ?Sized> {
+pub struct Root<'scope, 'gc, T: Trace + ?Sized> {
     ptr: Gc<T>,
     slot: RootSlotId,
-    _ctx: core::marker::PhantomData<&'gc mut GcContext>,
+    _scope: core::marker::PhantomData<&'scope Scope<'gc>>,
 }
 
 pub struct WeakGc<T: Trace + ?Sized> {
@@ -70,17 +70,25 @@ impl GcContext {
 
 impl<'gc> Scope<'gc> {
     pub fn alloc<T: Trace + 'static>(&mut self, value: T) -> Gc<T>;
-    pub fn root<T: Trace + 'static>(&'gc mut self, value: &Gc<T>) -> Root<'gc, T>;
+    pub fn root<'scope, T: Trace + 'static>(
+        &'scope self,
+        value: &Gc<T>,
+    ) -> Root<'scope, 'gc, T>;
     pub fn downgrade<T: Trace + 'static>(&self, value: &Gc<T>) -> WeakGc<T>;
 }
 
-impl<'gc, T: Trace + ?Sized> Root<'gc, T> {
+impl<'scope, 'gc, T: Trace + ?Sized> Root<'scope, 'gc, T> {
     pub fn gc(&self) -> &Gc<T>;
 }
 ```
 
-Safety note: `Root<'gc, T>` is lifetime-branded to the same `GcContext` scope,
-so safe code cannot hold rooted references after the context/scope is dropped.
+Safety note: `Root<'scope, 'gc, T>` is lifetime-branded to the borrowed scope,
+so safe code cannot hold rooted references after the owning scope/context is
+dropped.
+
+Implementation note: `Scope::root(&self, ...)` assumes root-slot registration is
+handled via internal mutability in collector internals, so multiple roots can
+coexist without requiring an exclusive borrow of `Scope`.
 
 ### Pointer identity and casts (parity-preserving)
 
@@ -126,9 +134,9 @@ edges in the same cycle.
 ### I2. Root slots replace root counts
 
 A value is rooted when at least one root slot references it. Slot lifetime is
-explicit (`Root<'gc, T>` drop unregisters slot), and root handles are branded by
-the context/scope lifetime so they cannot outlive the owning GC context. No
-per-object root/refcount math is used for liveness.
+explicit (`Root<'scope, 'gc, T>` drop unregisters slot), and root handles are
+branded by the scope/context lifetime so they cannot outlive the owning GC
+context. No per-object root/refcount math is used for liveness.
 
 ### I3. Weak upgrade semantics
 
@@ -154,13 +162,14 @@ finalizer-triggered graph activity.
 
 This proposal is intentionally structured in two layers:
 
-1. Collector-native API in Oscars (`GcContext`, `Scope`, `Root<'gc, T>`).
+1. Collector-native API in Oscars (`GcContext`, `Scope`, `Root<'scope, 'gc, T>`).
 2. Boa-compat layer that preserves current surface where required.
 
 ### Boa compatibility mapping
 
 1. `Gc::new(value)`:
-   - compatibility shim calls `with_gc_context(|cx| cx.scope(|s| s.alloc(value)))`.
+   - compatibility shim calls
+     `with_gc_context(|cx| cx.scope(|mut s| s.alloc(value)))`.
 2. `WeakGc::new/upgrade`, raw-pointer helpers, and cast helpers:
    - keep the same signatures.
 3. `force_collect()`:
@@ -193,11 +202,14 @@ This keeps migration incremental and avoids an all-at-once engine rewrite.
 
 1. Should `Scope<'gc>` be mandatory for all allocations, or should we keep a
    global-context fallback for Boa compatibility?
-2. Should `Root<T>` be cloneable (multiple slots) or explicitly unique?
+2. Should `Root<'scope, 'gc, T>` be cloneable (multiple slots) or explicitly
+   unique?
 3. Is `cast_ref_unchecked` still desirable, or should compatibility rely on
    value-consuming casts only?
 4. Which minimal Boa integration slice gives the best signal first:
    pointer API parity, weak semantics parity, or runtime helpers?
+5. Should reading `T` from `Gc<T>` require an explicit scope/root token, so
+   stale handles cannot be dereferenced after collection in safe code?
 
 ## Relationship to tracker work
 

--- a/notes/precise_tracing_api_plan.md
+++ b/notes/precise_tracing_api_plan.md
@@ -56,7 +56,7 @@ pub struct GcContext {
 }
 
 pub struct Scope<'gc> {
-    cx: &'gc GcContext,
+    cx: &'gc mut GcContext,
 }
 ```
 
@@ -64,8 +64,8 @@ pub struct Scope<'gc> {
 
 ```rust
 impl GcContext {
-    pub fn scope<R>(&self, f: impl for<'gc> FnOnce(Scope<'gc>) -> R) -> R;
-    pub fn collect(&self);
+    pub fn scope<R>(&mut self, f: impl for<'gc> FnOnce(Scope<'gc>) -> R) -> R;
+    pub fn collect(&mut self);
 }
 
 impl<'gc> Scope<'gc> {
@@ -83,16 +83,19 @@ impl<'scope, 'gc, T: Trace + ?Sized> Root<'scope, 'gc, T> {
 ```
 
 Safety note: `Root<'scope, 'gc, T>` is lifetime-branded to the borrowed scope,
-so safe code cannot hold rooted references after the owning scope/context is
-dropped.
+so root handles cannot outlive their owning scope/context in safe code.
 
 Implementation note: `Scope::root(&self, ...)` assumes root-slot registration is
 handled via internal mutability in collector internals, so multiple roots can
 coexist without requiring an exclusive borrow of `Scope`.
 
-Collection note: `collect(&self)` here represents a high-level API shape for a
-single-threaded runtime. Implementations should guard collection phase entry so
-collection cannot race with active mutable interior borrows.
+Collection note: `collect(&mut self)` is intentionally exclusive at API level.
+`GcContext::scope` and `collect` are mutually exclusive entry points in safe
+code, so collection cannot run while scope-borrowed operations are active.
+
+Root-slot note (v0 decision): `Root<'scope, 'gc, T>` is intentionally non-clone
+for now. Each root handle owns exactly one slot registration, and dropping that
+handle unregisters that slot.
 
 ### Pointer identity and casts (parity-preserving)
 
@@ -162,6 +165,11 @@ finalizers before destructors for tracked live values.
 Collector drop does not free values in an order that can cause UAF via
 finalizer-triggered graph activity.
 
+### I7. Collection entry exclusivity
+
+Collection requires exclusive context entry (`&mut GcContext`). Scope-driven API
+operations and collection cannot interleave through safe code.
+
 ## Feasibility and adoption path
 
 This proposal is intentionally structured in two layers:
@@ -177,7 +185,7 @@ This proposal is intentionally structured in two layers:
 2. `WeakGc::new/upgrade`, raw-pointer helpers, and cast helpers:
    - keep the same signatures.
 3. `force_collect()`:
-   - routed to collector `collect()`.
+   - routed to collector `collect()` through the mutable context entry path.
 4. `finalizer_safe()`:
    - routed to collector phase state.
 
@@ -206,15 +214,11 @@ This keeps migration incremental and avoids an all-at-once engine rewrite.
 
 1. Should `Scope<'gc>` be mandatory for all allocations, or should we keep a
    global-context fallback for Boa compatibility?
-2. Should `Root<'scope, 'gc, T>` be cloneable (multiple slots) or explicitly
-   unique?
-3. Should scope entry be closure-only (`GcContext::scope`) or should we also
-   support an explicit long-lived scope handle for ergonomics/integration?
-4. Is `cast_ref_unchecked` still desirable, or should compatibility rely on
+2. Is `cast_ref_unchecked` still desirable, or should compatibility rely on
    value-consuming casts only?
-5. Which minimal Boa integration slice gives the best signal first:
+3. Which minimal Boa integration slice gives the best signal first:
    pointer API parity, weak semantics parity, or runtime helpers?
-6. Should reading `T` from `Gc<T>` require an explicit scope/root token, so
+4. Should reading `T` from `Gc<T>` require an explicit scope/root token, so
    stale handles cannot be dereferenced after collection in safe code?
 
 ## Relationship to tracker work

--- a/notes/precise_tracing_api_plan.md
+++ b/notes/precise_tracing_api_plan.md
@@ -40,9 +40,10 @@ pub struct Gc<T: Trace + ?Sized> {
     _marker: core::marker::PhantomData<T>,
 }
 
-pub struct Root<T: Trace + ?Sized> {
+pub struct Root<'gc, T: Trace + ?Sized> {
     ptr: Gc<T>,
     slot: RootSlotId,
+    _ctx: core::marker::PhantomData<&'gc mut GcContext>,
 }
 
 pub struct WeakGc<T: Trace + ?Sized> {
@@ -69,14 +70,17 @@ impl GcContext {
 
 impl<'gc> Scope<'gc> {
     pub fn alloc<T: Trace + 'static>(&mut self, value: T) -> Gc<T>;
-    pub fn root<T: Trace + 'static>(&mut self, value: &Gc<T>) -> Root<T>;
+    pub fn root<T: Trace + 'static>(&'gc mut self, value: &Gc<T>) -> Root<'gc, T>;
     pub fn downgrade<T: Trace + 'static>(&self, value: &Gc<T>) -> WeakGc<T>;
 }
 
-impl<T: Trace + ?Sized> Root<T> {
+impl<'gc, T: Trace + ?Sized> Root<'gc, T> {
     pub fn gc(&self) -> &Gc<T>;
 }
 ```
+
+Safety note: `Root<'gc, T>` is lifetime-branded to the same `GcContext` scope,
+so safe code cannot hold rooted references after the context/scope is dropped.
 
 ### Pointer identity and casts (parity-preserving)
 
@@ -122,8 +126,9 @@ edges in the same cycle.
 ### I2. Root slots replace root counts
 
 A value is rooted when at least one root slot references it. Slot lifetime is
-explicit (`Root<T>` drop unregisters slot). No per-object root/refcount math is
-used for liveness.
+explicit (`Root<'gc, T>` drop unregisters slot), and root handles are branded by
+the context/scope lifetime so they cannot outlive the owning GC context. No
+per-object root/refcount math is used for liveness.
 
 ### I3. Weak upgrade semantics
 
@@ -149,7 +154,7 @@ finalizer-triggered graph activity.
 
 This proposal is intentionally structured in two layers:
 
-1. Collector-native API in Oscars (`GcContext`, `Scope`, `Root<T>`).
+1. Collector-native API in Oscars (`GcContext`, `Scope`, `Root<'gc, T>`).
 2. Boa-compat layer that preserves current surface where required.
 
 ### Boa compatibility mapping


### PR DESCRIPTION
﻿This PR adds a focused planning note for the GC redesign direction after removing the `gc_allocator` experiment path.

## What this adds
- `notes/precise_tracing_api_plan.md`
  - precise-tracing API direction without root/reference-count dependence
  - explicit invariants (rooting, weak/ephemeron, finalization/resurrection, teardown)
  - phased execution plan (contract + prototype + gated integration)
  - validation and risk controls aligned with current tracker issues
- README link for discoverability

## Why
Recent maintainer guidance points toward API-focused GC redesign and staged integration, while `#54` removes the `Collector: Allocator` experiment. This note captures a practical plan that matches that direction and keeps scope clear.

## Scope
- docs only
- no runtime/API behavior changes

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`
