### PR TITLE
mark_sweep: add Gc::ptr_eq parity helper

### DIFF
--- a/oscars/src/collectors/mark_sweep/pointers/gc.rs
+++ b/oscars/src/collectors/mark_sweep/pointers/gc.rs
@@ -43,6 +43,10 @@ impl<T: Trace> Gc<T> {
 }
 
 impl<T: Trace + ?Sized> Gc<T> {
+    pub fn ptr_eq<U: Trace + ?Sized>(this: &Self, other: &Gc<U>) -> bool {
+        this.inner_ptr.as_non_null() == other.inner_ptr.as_non_null()
+    }
+
     pub(crate) fn as_sized_inner_ptr(&self) -> NonNull<GcBox<NonTraceable>> {
         // SAFETY: use `&raw mut` to get a raw pointer without creating
         // a `&mut` reference, avoiding Stacked Borrows UB during GC tracing

--- a/oscars/src/collectors/mark_sweep/tests.rs
+++ b/oscars/src/collectors/mark_sweep/tests.rs
@@ -123,6 +123,30 @@ fn clone_gc() {
     collector.collect();
 
     assert_eq!(*gc_clone.borrow(), 42u32, "collected despite live clone");
+    assert!(
+        Gc::ptr_eq(&gc_clone, &gc_clone.clone()),
+        "cloned handles should compare equal by pointer identity"
+    );
+}
+
+#[test]
+fn ptr_eq_distinguishes_equal_values() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_page_size(256)
+        .with_heap_threshold(512);
+
+    let first = Gc::new_in(GcRefCell::new(42u32), collector);
+    let first_clone = first.clone();
+    let second = Gc::new_in(GcRefCell::new(42u32), collector);
+
+    assert!(
+        Gc::ptr_eq(&first, &first_clone),
+        "handles to the same allocation should compare equal"
+    );
+    assert!(
+        !Gc::ptr_eq(&first, &second),
+        "distinct allocations with equal values must not compare equal"
+    );
 }
 
 #[test]

--- a/oscars/src/collectors/mark_sweep_arena2/pointers/gc.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/pointers/gc.rs
@@ -46,6 +46,10 @@ impl<T: Trace> Gc<T> {
 }
 
 impl<T: Trace + ?Sized> Gc<T> {
+    pub fn ptr_eq<U: Trace + ?Sized>(this: &Self, other: &Gc<U>) -> bool {
+        this.inner_ptr.as_non_null() == other.inner_ptr.as_non_null()
+    }
+
     pub(crate) fn as_sized_inner_ptr(&self) -> NonNull<GcBox<NonTraceable>> {
         // SAFETY: `&raw mut` prevents creating `&mut` reference into the
         // arena to avoid stacked borrows during Gc tracing

--- a/oscars/src/collectors/mark_sweep_arena2/tests.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/tests.rs
@@ -134,6 +134,30 @@ fn clone_gc() {
     collector.collect();
 
     assert_eq!(*gc_clone.borrow(), 42u32, "collected despite live clone");
+    assert!(
+        Gc::ptr_eq(&gc_clone, &gc_clone.clone()),
+        "cloned handles should compare equal by pointer identity"
+    );
+}
+
+#[test]
+fn ptr_eq_distinguishes_equal_values() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let first = Gc::new_in(GcRefCell::new(42u32), collector);
+    let first_clone = first.clone();
+    let second = Gc::new_in(GcRefCell::new(42u32), collector);
+
+    assert!(
+        Gc::ptr_eq(&first, &first_clone),
+        "handles to the same allocation should compare equal"
+    );
+    assert!(
+        !Gc::ptr_eq(&first, &second),
+        "distinct allocations with equal values must not compare equal"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds `Gc::ptr_eq` to the active `oscars::mark_sweep` and `mark_sweep2` APIs.

## Why
`docs/boa_gc_api_parity.md` identifies pointer-identity comparison as part of the current Boa-facing `boa_gc` surface that Oscars does not yet expose.

Adding this helper closes one small but real parity gap and supports the staged integration work tracked in `#26` / `#28`.

## What changed
- added `Gc::ptr_eq(&Gc<T>, &Gc<U>) -> bool` for:
  - `oscars::mark_sweep::Gc<T>`
  - `oscars::mark_sweep2::Gc<T>`
- added focused tests covering:
  - same allocation => true
  - different allocations with equal values => false
  - cloned handles compare equal by pointer identity

## Scope
- small API parity addition
- no allocator or collector-policy changes

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`