### PR TITLE
mark_sweep: add Gc::cast_ref_unchecked parity API and tests

### DIFF
--- a/oscars/src/collectors/mark_sweep/pointers/gc.rs
+++ b/oscars/src/collectors/mark_sweep/pointers/gc.rs
@@ -93,6 +93,17 @@ impl<T: Trace> Gc<T> {
             marker: PhantomData,
         }
     }
+
+    /// Cast a `&Gc<T>` to `&Gc<U>` without consuming the handle.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `U` is the correct runtime type for `this`.
+    #[inline]
+    #[must_use]
+    pub unsafe fn cast_ref_unchecked<U: Trace + 'static>(this: &Self) -> &Gc<U> {
+        unsafe { &*(this as *const Self).cast::<Gc<U>>() }
+    }
 }
 
 impl<T: Trace> Gc<T> {

--- a/oscars/src/collectors/mark_sweep/tests.rs
+++ b/oscars/src/collectors/mark_sweep/tests.rs
@@ -150,6 +150,28 @@ fn ptr_eq_distinguishes_equal_values() {
 }
 
 #[test]
+fn cast_ref_unchecked_preserves_identity_and_value() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_page_size(256)
+        .with_heap_threshold(512);
+
+    let typed = Gc::new_in(13u32, collector);
+    let erased_as_u64: Gc<u64> = unsafe { Gc::cast_unchecked(typed.clone()) };
+
+    // SAFETY: `erased_as_u64` points to an allocation that actually stores `u32`.
+    let recovered_ref: &Gc<u32> = unsafe { Gc::cast_ref_unchecked(&erased_as_u64) };
+
+    assert_eq!(
+        **recovered_ref, 13u32,
+        "cast_ref_unchecked recovered wrong value"
+    );
+    assert!(
+        Gc::ptr_eq(&typed, recovered_ref),
+        "cast_ref_unchecked should preserve pointer identity"
+    );
+}
+
+#[test]
 fn multi_gc() {
     let collector = &mut MarkSweepGarbageCollector::default()
         .with_page_size(128)

--- a/oscars/src/collectors/mark_sweep_arena2/pointers/gc.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/pointers/gc.rs
@@ -97,6 +97,17 @@ impl<T: Trace> Gc<T> {
             marker: PhantomData,
         }
     }
+
+    /// Cast a `&Gc<T>` to `&Gc<U>` without consuming the handle.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `U` is the correct runtime type for `this`.
+    #[inline]
+    #[must_use]
+    pub unsafe fn cast_ref_unchecked<U: Trace + 'static>(this: &Self) -> &Gc<U> {
+        unsafe { &*(this as *const Self).cast::<Gc<U>>() }
+    }
 }
 
 impl<T: Trace> Gc<T> {

--- a/oscars/src/collectors/mark_sweep_arena2/tests.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/tests.rs
@@ -161,6 +161,28 @@ fn ptr_eq_distinguishes_equal_values() {
 }
 
 #[test]
+fn cast_ref_unchecked_preserves_identity_and_value() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let typed = Gc::new_in(13u32, collector);
+    let erased_as_u64: Gc<u64> = unsafe { Gc::cast_unchecked(typed.clone()) };
+
+    // SAFETY: `erased_as_u64` points to an allocation that actually stores `u32`.
+    let recovered_ref: &Gc<u32> = unsafe { Gc::cast_ref_unchecked(&erased_as_u64) };
+
+    assert_eq!(
+        **recovered_ref, 13u32,
+        "cast_ref_unchecked recovered wrong value"
+    );
+    assert!(
+        Gc::ptr_eq(&typed, recovered_ref),
+        "cast_ref_unchecked should preserve pointer identity"
+    );
+}
+
+#[test]
 fn multi_gc() {
     let collector = &mut MarkSweepGarbageCollector::default()
         .with_arena_size(128)


### PR DESCRIPTION
Part of #63

This PR adds `Gc::cast_ref_unchecked` parity support for both mark-sweep collectors and covers it with focused tests.

## What changed
- Added `unsafe fn Gc::cast_ref_unchecked<U>(&Gc<T>) -> &Gc<U>` in:
  - `mark_sweep`
  - `mark_sweep_arena2`
- Added tests in both collectors:
  - `cast_ref_unchecked_preserves_identity_and_value`

## Why
`cast_ref_unchecked` is still listed as a parity gap in #63.
This closes that gap without touching allocator/integration architecture.

## Scope
- pointer API parity + tests only
- no allocator policy changes
- no collector lifecycle changes

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace -q`
- `cargo clippy --workspace --all-features --all-targets -q`