### PR TITLE
mark_sweep: add Gc::new_cyclic_in parity semantics and tests

### DIFF
--- a/oscars/src/collectors/mark_sweep/internals/ephemeron.rs
+++ b/oscars/src/collectors/mark_sweep/internals/ephemeron.rs
@@ -66,6 +66,21 @@ impl<K: Trace, V: Trace> Ephemeron<K, V> {
     }
 }
 
+impl<K: Trace> Ephemeron<K, ()> {
+    pub(crate) fn new_empty(color: TraceColor) -> Self {
+        Self {
+            value: GcBox::new_in((), color),
+            vtable: vtable_of::<K, ()>(),
+            key: WeakGcBox::new_empty(),
+            active: core::cell::Cell::new(true),
+        }
+    }
+
+    pub(crate) fn set_key(&self, key: &Gc<K>) {
+        self.key.inner_ptr.set(Some(key.inner_ptr));
+    }
+}
+
 impl<K: Trace, V: Trace> Ephemeron<K, V> {
     pub(crate) fn trace_fn(&self) -> EphemeronTraceFn {
         self.vtable.trace_fn

--- a/oscars/src/collectors/mark_sweep/internals/gc_box.rs
+++ b/oscars/src/collectors/mark_sweep/internals/gc_box.rs
@@ -50,6 +50,13 @@ impl<T: Trace + Finalize + ?Sized> WeakGcBox<T> {
         }
     }
 
+    pub fn new_empty() -> Self {
+        Self {
+            inner_ptr: Cell::new(None),
+            marker: PhantomData,
+        }
+    }
+
     pub(crate) fn erased_inner_ptr(&self) -> Option<NonNull<GcBox<NonTraceable>>> {
         // SAFETY: `as_heap_ptr` returns a valid pointer to
         // `PoolItem` whose lifetime is tied to the pool

--- a/oscars/src/collectors/mark_sweep/mod.rs
+++ b/oscars/src/collectors/mark_sweep/mod.rs
@@ -51,6 +51,10 @@ pub trait Collector {
         value: V,
     ) -> Result<PoolPointer<'gc, Ephemeron<K, V>>, PoolAllocError>;
 
+    fn alloc_empty_ephemeron_node<'gc, K: Trace + 'static>(
+        &'gc self,
+    ) -> Result<PoolPointer<'gc, Ephemeron<K, ()>>, PoolAllocError>;
+
     // Register a weak map with the GC so it can prune dead entries
     #[doc(hidden)]
     fn track_weak_map(&self, map: core::ptr::NonNull<dyn ErasedWeakMap>);
@@ -471,6 +475,38 @@ impl Collector for MarkSweepGarbageCollector {
         let ephemeron = Ephemeron::new(key, value, self.trace_color.get());
 
         // try_alloc creates a new arena page on OOM
+        let mut alloc = self.allocator.borrow_mut();
+        let inner_ptr = alloc.try_alloc(ephemeron)?;
+        let needs_collect = !alloc.is_below_threshold();
+        drop(alloc);
+
+        if needs_collect {
+            self.collect_needed.set(true);
+        }
+
+        let eph_ptr = inner_ptr
+            .as_ptr()
+            .cast::<PoolItem<Ephemeron<NonTraceable, NonTraceable>>>();
+
+        if self.is_collecting.get() {
+            self.pending_ephemeron_queue.borrow_mut().push(eph_ptr);
+        } else {
+            self.ephemeron_queue.borrow_mut().push(eph_ptr);
+        }
+
+        Ok(inner_ptr)
+    }
+
+    fn alloc_empty_ephemeron_node<'gc, K: Trace + 'static>(
+        &'gc self,
+    ) -> Result<PoolPointer<'gc, Ephemeron<K, ()>>, crate::alloc::mempool3::PoolAllocError> {
+        if self.collect_needed.get() && !self.is_collecting.get() {
+            self.collect_needed.set(false);
+            self.collect();
+        }
+
+        let ephemeron = Ephemeron::<K, ()>::new_empty(self.trace_color.get());
+
         let mut alloc = self.allocator.borrow_mut();
         let inner_ptr = alloc.try_alloc(ephemeron)?;
         let needs_collect = !alloc.is_below_threshold();

--- a/oscars/src/collectors/mark_sweep/pointers/gc.rs
+++ b/oscars/src/collectors/mark_sweep/pointers/gc.rs
@@ -35,6 +35,26 @@ impl<T: Trace> Gc<T> {
         gc
     }
 
+    #[must_use]
+    pub fn new_cyclic_in<C, F>(collector: &C, data_fn: F) -> Self
+    where
+        C: Collector,
+        F: FnOnce(&crate::collectors::mark_sweep::WeakGc<T>) -> T,
+    {
+        let weak = unsafe {
+            crate::collectors::mark_sweep::WeakGc::from_raw(
+                collector
+                    .alloc_empty_ephemeron_node::<T>()
+                    .expect("Failed to allocate Ephemeron node")
+                    .extend_lifetime(),
+            )
+        };
+
+        let gc = Self::new_in(data_fn(&weak), collector);
+        weak.set_key(&gc);
+        gc
+    }
+
     /// Converts a `Gc` into a raw [`PoolPointer`].
     pub fn into_raw(this: Self) -> PoolPointer<'static, GcBox<T>> {
         let ptr = this.inner_ptr();

--- a/oscars/src/collectors/mark_sweep/pointers/weak.rs
+++ b/oscars/src/collectors/mark_sweep/pointers/weak.rs
@@ -34,4 +34,12 @@ impl<T: Trace> WeakGc<T> {
     pub fn upgrade(&self) -> Option<Gc<T>> {
         self.inner_ptr.as_inner_ref().upgrade()
     }
+
+    pub(crate) unsafe fn from_raw(inner_ptr: PoolPointer<'static, Ephemeron<T, ()>>) -> Self {
+        Self { inner_ptr }
+    }
+
+    pub(crate) fn set_key(&self, key: &Gc<T>) {
+        self.inner_ptr.as_inner_ref().set_key(key);
+    }
 }

--- a/oscars/src/collectors/mark_sweep/tests.rs
+++ b/oscars/src/collectors/mark_sweep/tests.rs
@@ -241,6 +241,25 @@ fn cast_ref_unchecked_preserves_identity_and_value() {
 }
 
 #[test]
+fn new_cyclic_closure_cannot_upgrade_before_init() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_page_size(256)
+        .with_heap_threshold(512);
+
+    let mut saw_none = false;
+    let gc = Gc::new_cyclic_in(collector, |weak| {
+        saw_none = weak.upgrade().is_none();
+        7u32
+    });
+
+    assert!(
+        saw_none,
+        "weak should not upgrade during new_cyclic construction"
+    );
+    assert_eq!(*gc, 7u32, "new_cyclic should initialize final value");
+}
+
+#[test]
 fn multi_gc() {
     let collector = &mut MarkSweepGarbageCollector::default()
         .with_page_size(128)

--- a/oscars/src/collectors/mark_sweep_arena2/internals/ephemeron.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/internals/ephemeron.rs
@@ -62,6 +62,21 @@ impl<K: Trace, V: Trace> Ephemeron<K, V> {
     }
 }
 
+impl<K: Trace> Ephemeron<K, ()> {
+    pub(crate) fn new_empty(color: TraceColor) -> Self {
+        Self {
+            value: GcBox::new_in((), color),
+            vtable: vtable_of::<K, ()>(),
+            key: WeakGcBox::new_empty(),
+            active: core::cell::Cell::new(true),
+        }
+    }
+
+    pub(crate) fn set_key(&self, key: &Gc<K>) {
+        self.key.inner_ptr.set(Some(key.inner_ptr));
+    }
+}
+
 impl<K: Trace, V: Trace> Ephemeron<K, V> {
     pub(crate) fn trace_fn(&self) -> EphemeronTraceFn {
         self.vtable.trace_fn

--- a/oscars/src/collectors/mark_sweep_arena2/internals/gc_box.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/internals/gc_box.rs
@@ -44,6 +44,13 @@ impl<T: Trace + Finalize + ?Sized> WeakGcBox<T> {
         }
     }
 
+    pub fn new_empty() -> Self {
+        Self {
+            inner_ptr: Cell::new(None),
+            marker: PhantomData,
+        }
+    }
+
     pub(crate) fn erased_inner_ptr(&self) -> Option<NonNull<GcBox<NonTraceable>>> {
         // SAFETY: `&raw mut` prevents creating `&mut` reference into the
         // arena to avoid stacked borrows during Gc tracing

--- a/oscars/src/collectors/mark_sweep_arena2/mod.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/mod.rs
@@ -57,6 +57,13 @@ pub trait Collector {
         crate::alloc::arena2::ArenaAllocError,
     >;
 
+    fn alloc_empty_ephemeron_node<'gc, K: Trace + 'static>(
+        &'gc self,
+    ) -> Result<
+        crate::alloc::arena2::ArenaPointer<'gc, internals::Ephemeron<K, ()>>,
+        crate::alloc::arena2::ArenaAllocError,
+    >;
+
     // Register a weak map with the GC so it can prune dead entries.
     #[doc(hidden)]
     fn track_weak_map(&self, map: core::ptr::NonNull<dyn ErasedWeakMap>);
@@ -464,6 +471,38 @@ impl Collector for MarkSweepGarbageCollector {
         }
 
         let ephemeron = Ephemeron::new(key, value, self.trace_color.get());
+
+        let mut alloc = self.allocator.borrow_mut();
+        let inner_ptr = alloc.try_alloc(ephemeron)?;
+        let needs_collect = !alloc.is_below_threshold();
+        drop(alloc);
+
+        if needs_collect {
+            self.collect_needed.set(true);
+        }
+
+        let eph_ptr = inner_ptr
+            .as_ptr()
+            .cast::<ArenaHeapItem<Ephemeron<NonTraceable, NonTraceable>>>();
+
+        if self.is_collecting.get() {
+            self.pending_ephemeron_queue.borrow_mut().push(eph_ptr);
+        } else {
+            self.ephemeron_queue.borrow_mut().push(eph_ptr);
+        }
+
+        Ok(inner_ptr)
+    }
+
+    fn alloc_empty_ephemeron_node<'gc, K: Trace + 'static>(
+        &'gc self,
+    ) -> Result<ArenaPointer<'gc, Ephemeron<K, ()>>, crate::alloc::arena2::ArenaAllocError> {
+        if self.collect_needed.get() && !self.is_collecting.get() {
+            self.collect_needed.set(false);
+            self.collect();
+        }
+
+        let ephemeron = Ephemeron::<K, ()>::new_empty(self.trace_color.get());
 
         let mut alloc = self.allocator.borrow_mut();
         let inner_ptr = alloc.try_alloc(ephemeron)?;

--- a/oscars/src/collectors/mark_sweep_arena2/pointers/gc.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/pointers/gc.rs
@@ -1,5 +1,6 @@
 use crate::alloc::arena2::{ArenaHeapItem, ArenaPointer, ErasedArenaPointer};
 
+use crate::collectors::mark_sweep_arena2::Collector;
 use crate::collectors::mark_sweep_arena2::Finalize;
 use crate::collectors::mark_sweep_arena2::internals::NonTraceable;
 use crate::collectors::mark_sweep_arena2::{Trace, internals::GcBox};
@@ -34,6 +35,28 @@ impl<T: Trace> Gc<T> {
         };
         // GcBox is allocated with 0 roots, increment to 1 for the new handle
         gc.inner_ptr().as_inner_ref().inc_roots();
+        gc
+    }
+
+    #[must_use]
+    pub fn new_cyclic_in<F>(
+        collector: &crate::collectors::mark_sweep_arena2::MarkSweepGarbageCollector,
+        data_fn: F,
+    ) -> Self
+    where
+        F: FnOnce(&crate::collectors::mark_sweep_arena2::WeakGc<T>) -> T,
+    {
+        let weak = unsafe {
+            crate::collectors::mark_sweep_arena2::WeakGc::from_raw(
+                collector
+                    .alloc_empty_ephemeron_node::<T>()
+                    .expect("Failed to allocate Ephemeron node")
+                    .extend_lifetime(),
+            )
+        };
+
+        let gc = Self::new_in(data_fn(&weak), collector);
+        weak.set_key(&gc);
         gc
     }
 

--- a/oscars/src/collectors/mark_sweep_arena2/pointers/weak.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/pointers/weak.rs
@@ -37,4 +37,12 @@ impl<T: Trace> WeakGc<T> {
     pub fn upgrade(&self) -> Option<Gc<T>> {
         self.inner_ptr.as_inner_ref().upgrade()
     }
+
+    pub(crate) unsafe fn from_raw(inner_ptr: ArenaPointer<'static, Ephemeron<T, ()>>) -> Self {
+        Self { inner_ptr }
+    }
+
+    pub(crate) fn set_key(&self, key: &Gc<T>) {
+        self.inner_ptr.as_inner_ref().set_key(key);
+    }
 }

--- a/oscars/src/collectors/mark_sweep_arena2/tests.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/tests.rs
@@ -252,6 +252,25 @@ fn cast_ref_unchecked_preserves_identity_and_value() {
 }
 
 #[test]
+fn new_cyclic_closure_cannot_upgrade_before_init() {
+    let collector = &mut MarkSweepGarbageCollector::default()
+        .with_arena_size(256)
+        .with_heap_threshold(512);
+
+    let mut saw_none = false;
+    let gc = Gc::new_cyclic_in(collector, |weak| {
+        saw_none = weak.upgrade().is_none();
+        7u32
+    });
+
+    assert!(
+        saw_none,
+        "weak should not upgrade during new_cyclic construction"
+    );
+    assert_eq!(*gc, 7u32, "new_cyclic should initialize final value");
+}
+
+#[test]
 fn multi_gc() {
     let collector = &mut MarkSweepGarbageCollector::default()
         .with_arena_size(128)


### PR DESCRIPTION
Part of #63

This PR adds `Gc::new_cyclic_in` parity support for both mark-sweep collectors, following Boa semantics where `weak.upgrade()` returns `None` inside the construction closure until the object is fully initialized.

## What changed
- Added `Gc::new_cyclic_in` in:
  - `mark_sweep::pointers::Gc`
  - `mark_sweep_arena2::pointers::Gc`
- Added empty ephemeron allocation path used by cyclic bootstrap:
  - `alloc_empty_ephemeron_node` in mark-sweep collector APIs
  - matching arena2 collector allocation helper
- Added internal helpers to support deferred key binding:
  - `WeakGcBox::new_empty`
  - `Ephemeron::<K, ()>::new_empty`
  - `Ephemeron::<K, ()>::set_key`
  - `WeakGc::from_raw` + `WeakGc::set_key` (crate-visible)
- Added parity tests in both collectors:
  - `new_cyclic_closure_cannot_upgrade_before_init`

## Why
`Gc::new_cyclic` is still listed as a parity gap in #63.
This closes that gap while keeping scope limited to mark-sweep internals and tests.

## Scope
- API parity + tests only
- no allocator policy tuning
- no integration path changes

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace -q`
- `cargo clippy --workspace --all-features --all-targets -q`