### PR TITLE
gc: add finalizer_safe() parity API across mark-sweep collectors

### DIFF
--- a/oscars/src/collectors/mark_sweep/mod.rs
+++ b/oscars/src/collectors/mark_sweep/mod.rs
@@ -95,6 +95,12 @@ impl MarkSweepGarbageCollector {
     pub fn pools_len(&self) -> usize {
         self.allocator.borrow().pools_len()
     }
+
+    /// Returns true when the collector is not inside an active collection
+    /// cycle, i.e. it is safe to run external finalizer-sensitive paths.
+    pub fn finalizer_safe(&self) -> bool {
+        !self.is_collecting.get()
+    }
 }
 
 impl Drop for MarkSweepGarbageCollector {

--- a/oscars/src/collectors/mark_sweep/tests.rs
+++ b/oscars/src/collectors/mark_sweep/tests.rs
@@ -855,6 +855,60 @@ mod gc_edge_cases {
         let _value = *flag.borrow();
     }
 
+    #[test]
+    fn finalizer_safe_reflects_collecting_state() {
+        use core::sync::atomic::{AtomicU8, Ordering};
+
+        // 0 = not observed, 1 = true, 2 = false
+        static OBSERVED: AtomicU8 = AtomicU8::new(0);
+
+        struct Probe {
+            collector: core::ptr::NonNull<MarkSweepGarbageCollector>,
+        }
+
+        impl Finalize for Probe {}
+
+        unsafe impl Trace for Probe {
+            unsafe fn trace(&self, _color: crate::mark_sweep::TraceColor) {
+                let safe = unsafe { self.collector.as_ref().finalizer_safe() };
+                OBSERVED.store(if safe { 1 } else { 2 }, Ordering::SeqCst);
+            }
+
+            fn run_finalizer(&self) {
+                Finalize::finalize(self);
+            }
+        }
+
+        let collector = &mut MarkSweepGarbageCollector::default()
+            .with_page_size(256)
+            .with_heap_threshold(512);
+
+        assert!(
+            collector.finalizer_safe(),
+            "collector should report finalizer-safe while idle"
+        );
+
+        OBSERVED.store(0, Ordering::SeqCst);
+        let _root = Gc::new_in(
+            Probe {
+                collector: core::ptr::NonNull::from(&*collector),
+            },
+            collector,
+        );
+
+        collector.collect();
+
+        assert_eq!(
+            OBSERVED.load(Ordering::SeqCst),
+            2,
+            "trace-time observation should see finalizer_safe() == false during collection"
+        );
+        assert!(
+            collector.finalizer_safe(),
+            "collector should return to finalizer-safe state after collection"
+        );
+    }
+
     // ---- Multiple collections on the same graph ---------------------------
 
     /// Run GC repeatedly while objects are still alive to verify that

--- a/oscars/src/collectors/mark_sweep_arena2/mod.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/mod.rs
@@ -84,6 +84,12 @@ impl MarkSweepGarbageCollector {
     pub fn arenas_len(&self) -> usize {
         self.allocator.borrow().arenas_len()
     }
+
+    /// Returns true when the collector is not inside an active collection
+    /// cycle, i.e. it is safe to run external finalizer-sensitive paths.
+    pub fn finalizer_safe(&self) -> bool {
+        !self.is_collecting.get()
+    }
 }
 
 impl Drop for MarkSweepGarbageCollector {

--- a/oscars/src/collectors/mark_sweep_arena2/tests.rs
+++ b/oscars/src/collectors/mark_sweep_arena2/tests.rs
@@ -901,6 +901,60 @@ mod gc_edge_cases {
         let _value = *flag.borrow();
     }
 
+    #[test]
+    fn finalizer_safe_reflects_collecting_state() {
+        use core::sync::atomic::{AtomicU8, Ordering};
+
+        // 0 = not observed, 1 = true, 2 = false
+        static OBSERVED: AtomicU8 = AtomicU8::new(0);
+
+        struct Probe {
+            collector: core::ptr::NonNull<MarkSweepGarbageCollector>,
+        }
+
+        impl Finalize for Probe {}
+
+        unsafe impl Trace for Probe {
+            unsafe fn trace(&self, _color: TraceColor) {
+                let safe = unsafe { self.collector.as_ref().finalizer_safe() };
+                OBSERVED.store(if safe { 1 } else { 2 }, Ordering::SeqCst);
+            }
+
+            fn run_finalizer(&self) {
+                Finalize::finalize(self);
+            }
+        }
+
+        let collector = &mut MarkSweepGarbageCollector::default()
+            .with_arena_size(256)
+            .with_heap_threshold(512);
+
+        assert!(
+            collector.finalizer_safe(),
+            "collector should report finalizer-safe while idle"
+        );
+
+        OBSERVED.store(0, Ordering::SeqCst);
+        let _root = Gc::new_in(
+            Probe {
+                collector: core::ptr::NonNull::from(&*collector),
+            },
+            collector,
+        );
+
+        collector.collect();
+
+        assert_eq!(
+            OBSERVED.load(Ordering::SeqCst),
+            2,
+            "trace-time observation should see finalizer_safe() == false during collection"
+        );
+        assert!(
+            collector.finalizer_safe(),
+            "collector should return to finalizer-safe state after collection"
+        );
+    }
+
     // ---- Multiple collections on the same graph ---------------------------
 
     /// Run GC repeatedly while objects are still alive to verify that


### PR DESCRIPTION
Part of #78 and #63.

This PR adds `finalizer_safe()` runtime utility parity in both mark-sweep collectors and validates its behavior with focused tests.

What changed
- Added `MarkSweepGarbageCollector::finalizer_safe(&self) -> bool` in:
  - `collectors/mark_sweep/mod.rs`
  - `collectors/mark_sweep_arena2/mod.rs`
- Added parity tests in both collector test suites:
  - `finalizer_safe_reflects_collecting_state`

Behavior validated by tests
- `finalizer_safe()` returns `true` while idle.
- `finalizer_safe()` returns `false` when observed from inside `Trace::trace` during an active collection cycle.
- After collection completes, `finalizer_safe()` returns `true` again.

Scope
- runtime utility parity + tests only
- no allocator policy changes
- no collector algorithm changes
- no Boa integration wiring changes

Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace -q`
- `cargo clippy --workspace --all-features --all-targets -q`
- `cargo +nightly miri test -p oscars --all-features -q`